### PR TITLE
Fixed typo and shorten grade 70 in the coin grading YAML.

### DIFF
--- a/OpenNumismat/Functions/Coin_Grading_Standards.YAML
+++ b/OpenNumismat/Functions/Coin_Grading_Standards.YAML
@@ -2,7 +2,7 @@
   Link: "https://www.pcgs.com/grades"
 
 - Grade: 70
-  Description: Fully struck and lustrous, free of visual marks.   The PCGS 70 grading standard does allow for as minted defects, as long as those flaws are minor and do not impact the eye appeal of the coin.
+  Description: Fully struck, lustrous, no visual marks except minor mint defects.
   Name: MS/PR-70
   GradeCategory: Mint State/Proof State
 
@@ -83,7 +83,7 @@
 
 - Grade: 40
   Description: All design elements still show, but high points now worn flat. Little to no luster remains.
-  Name: XF-45
+  Name: XF-40
   GradeCategory: Extremely Fine
 
 - Grade: 35


### PR DESCRIPTION
Fixed typo and shorten grade 70 in the coin grading YAML.